### PR TITLE
Load the available lexers from pygmentize output

### DIFF
--- a/pp-source-format/Properties/Settings.Designer.cs
+++ b/pp-source-format/Properties/Settings.Designer.cs
@@ -25,7 +25,7 @@ namespace pp_source_format.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("java")]
+        [global::System.Configuration.DefaultSettingValueAttribute("Java")]
         public string SelectedLanguage {
             get {
                 return ((string)(this["SelectedLanguage"]));

--- a/pp-source-format/Ribbon.Designer.cs
+++ b/pp-source-format/Ribbon.Designer.cs
@@ -34,10 +34,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            Microsoft.Office.Tools.Ribbon.RibbonDropDownItem ribbonDropDownItemImpl1 = this.Factory.CreateRibbonDropDownItem();
-            Microsoft.Office.Tools.Ribbon.RibbonDropDownItem ribbonDropDownItemImpl2 = this.Factory.CreateRibbonDropDownItem();
-            Microsoft.Office.Tools.Ribbon.RibbonDropDownItem ribbonDropDownItemImpl3 = this.Factory.CreateRibbonDropDownItem();
-            Microsoft.Office.Tools.Ribbon.RibbonDropDownItem ribbonDropDownItemImpl4 = this.Factory.CreateRibbonDropDownItem();
             this.tab1 = this.Factory.CreateRibbonTab();
             this.group1 = this.Factory.CreateRibbonGroup();
             this.bxUnavailable = this.Factory.CreateRibbonBox();
@@ -102,24 +98,14 @@
             // 
             // cmbLanguage
             // 
-            ribbonDropDownItemImpl1.Label = "java";
-            ribbonDropDownItemImpl2.Label = "c";
-            this.cmbLanguage.Items.Add(ribbonDropDownItemImpl1);
-            this.cmbLanguage.Items.Add(ribbonDropDownItemImpl2);
             this.cmbLanguage.Label = "Language";
             this.cmbLanguage.Name = "cmbLanguage";
-            this.cmbLanguage.Text = "java";
             this.cmbLanguage.TextChanged += new Microsoft.Office.Tools.Ribbon.RibbonControlEventHandler(this.OnLanguageChanged);
             // 
             // cmbStyle
             // 
-            ribbonDropDownItemImpl3.Label = "default";
-            ribbonDropDownItemImpl4.Label = "vs";
-            this.cmbStyle.Items.Add(ribbonDropDownItemImpl3);
-            this.cmbStyle.Items.Add(ribbonDropDownItemImpl4);
             this.cmbStyle.Label = "Style";
             this.cmbStyle.Name = "cmbStyle";
-            this.cmbStyle.Text = "default";
             this.cmbStyle.TextChanged += new Microsoft.Office.Tools.Ribbon.RibbonControlEventHandler(this.OnStyleChanged);
             // 
             // btnFormatCurrent

--- a/pp-source-format/Ribbon.cs
+++ b/pp-source-format/Ribbon.cs
@@ -22,12 +22,37 @@ namespace pp_source_format
         /// </summary>
         private void ReflectPygmentizeStatus()
         {
+            var configuration = Formatter.GetConfiguration();
+
             if (Pygments.FoundPygmentize)
             {
                 lblPygmentsAvailable.SuperTip = Pygments.PygmentizePath;
 
                 SetBoxVisible(bxAvailable, true);
                 SetBoxVisible(bxUnavailable, false);
+
+                cmbLanguage.Items.Clear();
+                cmbStyle.Items.Clear();
+
+                foreach (var lexer in configuration.Lexers)
+                {
+                    var item = Factory.CreateRibbonDropDownItem();
+                    item.Label = lexer;
+                    cmbLanguage.Items.Add(item);
+                }
+
+                cmbLanguage.Text = CurrentSettings.SelectedLanguage;
+
+                foreach (var style in configuration.Styles)
+                {
+                    var item = Factory.CreateRibbonDropDownItem();
+                    item.Label = style.Name;
+                    item.ScreenTip = style.Info;
+                    cmbStyle.Items.Add(item);
+                }
+
+                cmbStyle.Text = CurrentSettings.SelectedStyle;
+                
             }
             else
             {

--- a/pp-source-format/app.config
+++ b/pp-source-format/app.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="pp_source_format.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
@@ -15,4 +15,12 @@
             </setting>
         </pp_source_format.Properties.Settings>
     </userSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/pp-source-format/packages.config
+++ b/pp-source-format/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net472" />
+  <package id="System.Text.Json" version="8.0.3" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
+</packages>

--- a/pp-source-format/pp-source-format.csproj
+++ b/pp-source-format/pp-source-format.csproj
@@ -33,7 +33,7 @@
     <PublishUrl>publish\</PublishUrl>
     <InstallUrl />
     <TargetCulture>en</TargetCulture>
-    <ApplicationVersion>0.1.0.4</ApplicationVersion>
+    <ApplicationVersion>0.1.0.5</ApplicationVersion>
     <AutoIncrementApplicationRevision>true</AutoIncrementApplicationRevision>
     <UpdateEnabled>false</UpdateEnabled>
     <UpdateInterval>0</UpdateInterval>
@@ -123,9 +123,38 @@
   -->
   <ItemGroup>
     <Reference Include="Accessibility" />
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=8.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.8.0.3\lib\net462\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
@@ -195,6 +224,7 @@
       <DependentUpon>Ribbon.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="app.config" />
+    <None Include="packages.config" />
     <None Include="pp-source-format_TemporaryKey.pfx" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>


### PR DESCRIPTION
With this PR the addin loads the available lexers automatically from the output of `pygmentize -L --json`.
The PR also fixes an occasional deadlock when reading process outputs.